### PR TITLE
perf: Refactor code to async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ results/
 *.png
 
 results*
+
+.idea

--- a/leaderboard/agent.py
+++ b/leaderboard/agent.py
@@ -1,14 +1,14 @@
 from typing import Any
-from letta_client import Letta, LlmConfig, EmbeddingConfig
+from letta_client import AsyncLetta, LlmConfig, EmbeddingConfig
 
 
-def create_base_agent(
-    client: Letta,
+async def create_base_agent(
+    client: AsyncLetta,
     datum: Any,
     llm_config: LlmConfig,
     embedding_config: EmbeddingConfig,
 ) -> str:
-    agent_id = client.agents.create(
+    agent = await client.agents.create(
         llm_config=llm_config, embedding_config=embedding_config
-    ).id
-    return agent_id
+    )
+    return agent.id

--- a/leaderboard/benchmark.py
+++ b/leaderboard/benchmark.py
@@ -18,7 +18,7 @@ class Benchmark(metaclass=ABCMeta):
 
     @abstractmethod
     async def metric(
-        self, predicted_answer: str, true_answer: str, datum: Dotdict, agent_id=None
+        self, predicted: str, true: str, datum: Dotdict, agent_id: str
     ) -> float:
         pass
 

--- a/leaderboard/benchmark.py
+++ b/leaderboard/benchmark.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod, ABCMeta
-from typing import Literal
+from typing import Literal, Optional, Callable
 from letta_client import AsyncLetta, LettaResponse, MessageCreate
 
 from leaderboard.utils import Dotdict, EvaluationResult, UsageStatistics
@@ -8,9 +8,12 @@ from leaderboard.utils import Dotdict, EvaluationResult, UsageStatistics
 class Benchmark(metaclass=ABCMeta):
     dataset: list[Dotdict]
     benchmark_type: Literal["general", "feature"]
+    create_agent_fun: Optional[Callable] = None
 
     @abstractmethod
-    async def setup_agent(self, datum: Dotdict, client: AsyncLetta, agent_id: str) -> None:
+    async def setup_agent(
+        self, datum: Dotdict, client: AsyncLetta, agent_id: str
+    ) -> None:
         pass
 
     @abstractmethod

--- a/leaderboard/evaluate.py
+++ b/leaderboard/evaluate.py
@@ -44,7 +44,9 @@ async def evaluate(
             messages=[MessageCreate(role="user", content=datum.message)],
         )
         predicted_answer = extract_last_message(response)
-        current_score = await benchmark.metric(predicted_answer, datum.answer, datum, agent_id)
+        current_score = await benchmark.metric(
+            predicted_answer, datum.answer, datum, agent_id
+        )
         individual_scores.append(current_score)
         total_score += current_score
         input_tokens += response.usage.prompt_tokens
@@ -77,7 +79,9 @@ async def run_single_data(
             messages=[MessageCreate(role="user", content=datum.message)],
         )
         predicted_answer = extract_last_message(response)
-        score = await benchmark.metric(predicted_answer, datum.answer, datum.message, agent_id)
+        score = await benchmark.metric(
+            predicted_answer, datum.answer, datum.message, agent_id
+        )
         return (
             agent_id,
             score,
@@ -268,16 +272,18 @@ async def main():
     )
 
     if getattr(benchmark, "create_agent_fun", None):
-        create_base_agent_fun = lambda c, d: benchmark.create_agent_fun(
-            c, d, llm_config, embedding_config
-        )
+
+        def create_base_agent_fun(c, d):
+            return benchmark.create_agent_fun(c, d, llm_config, embedding_config)
     else:
         create_base_agent_fun = create_base_agent
 
     benchmark.truncate_dataset(args.dataset_size)
 
     for i in range(args.repeat_from, args.repeat):
-        print(f"[green]Running eval {i+1}/{args.repeat} for {args.benchmark_variable}[/green]")
+        print(
+            f"[green]Running eval {i + 1}/{args.repeat} for {args.benchmark_variable}[/green]"
+        )
         result = await evaluate_concurrent(
             benchmark,
             client,
@@ -285,12 +291,14 @@ async def main():
             # num_thread=args.num_threads,
             timeout=args.timeout,
         )
-        out_dir = f"results/{args.benchmark}_{args.benchmark_variable}_{args.dataset_size}"
+        out_dir = (
+            f"results/{args.benchmark}_{args.benchmark_variable}_{args.dataset_size}"
+        )
         os.makedirs(out_dir, exist_ok=True)
         base = (
-            args.output_file + f"_{i+1}"
+            args.output_file + f"_{i + 1}"
             if args.output_file
-            else f"{out_dir}/{args.model}{args.result_name_suffix}_{i+1}"
+            else f"{out_dir}/{args.model}{args.result_name_suffix}_{i + 1}"
         )
         write_result(result, client_settings, args.model, f"{base}.json")
 

--- a/leaderboard/evaluate.py
+++ b/leaderboard/evaluate.py
@@ -1,58 +1,50 @@
 import argparse
-from concurrent.futures import ThreadPoolExecutor, as_completed, ProcessPoolExecutor
-import datetime
 import importlib
 import json
 import os
-from typing import Callable
+import datetime
+import traceback
+import asyncio
+from typing import Callable, Any
 from tqdm import tqdm
-from letta_client import LettaResponse, MessageCreate
+from rich import print
+
+from letta_client import AsyncLetta, MessageCreate, LlmConfig, EmbeddingConfig
 from leaderboard.agent import create_base_agent
 from leaderboard.benchmark import Benchmark
-from letta_client import Letta, LlmConfig, EmbeddingConfig
-from rich import print
-import traceback
-
-from leaderboard.utils import (
-    EvaluationResult,
-    write_result,
-    write_usage_statistics,
-)
+from leaderboard.utils import EvaluationResult, write_result, write_usage_statistics
 
 
-def extract_last_message(response: LettaResponse) -> str:
+def extract_last_message(response: Any) -> str:
     for message in response.messages[::-1]:
         if message.message_type == "assistant_message":
             return message.content
-    # print(f"[red]No message found in response {response}[/red]")
     return ""
 
 
-def evaluate(
+async def evaluate(
     benchmark: Benchmark,
-    client: Letta,
-    create_agent_fun: Callable[[Letta], str],
+    client: AsyncLetta,
+    create_agent_fun: Callable[[AsyncLetta, Any], asyncio.Future],
 ) -> EvaluationResult:
     total_score = 0
     total = len(benchmark.dataset)
     individual_scores = []
-
-    progress_bar = tqdm(benchmark.dataset, desc=f"Score: {total_score}/{total}")
     agent_ids = []
-
     input_tokens = 0
     output_tokens = 0
 
+    progress_bar = tqdm(benchmark.dataset, desc=f"Score: {total_score}/{total}")
+
     for datum in progress_bar:
-        agent_id = create_agent_fun(client)
-        benchmark.setup_agent(
-            datum, client, agent_id
-        )  # sets up the agent for current data
-        response = client.send_message(
-            agent_id=agent_id, message=datum.message, role="user"
+        agent_id = await create_agent_fun(client, datum)
+        await benchmark.setup_agent(datum, client, agent_id)
+        response = await client.agents.messages.create(
+            agent_id=agent_id,
+            messages=[MessageCreate(role="user", content=datum.message)],
         )
         predicted_answer = extract_last_message(response)
-        current_score = benchmark.metric(predicted_answer, datum.answer)
+        current_score = await benchmark.metric(predicted_answer, datum.answer, datum, agent_id)
         individual_scores.append(current_score)
         total_score += current_score
         input_tokens += response.usage.prompt_tokens
@@ -71,25 +63,21 @@ def evaluate(
     )
 
 
-def run_single_data(datum, create_agent_fun, client, benchmark):
-    agent_id = create_agent_fun(client)
-    benchmark.setup_agent(datum, client, agent_id)  # sets up the agent for current data
+async def run_single_data(
+    datum: Any,
+    create_agent_fun: Callable[[AsyncLetta, Any], asyncio.Future],
+    client: AsyncLetta,
+    benchmark: Benchmark,
+):
+    agent_id = await create_agent_fun(client, datum)
+    await benchmark.setup_agent(datum, client, agent_id)
     try:
-        response = client.agents.messages.create(
+        response = await client.agents.messages.create(
             agent_id=agent_id,
-            messages=[
-                MessageCreate(
-                    role="user",
-                    content=datum.message,
-                )
-            ],
+            messages=[MessageCreate(role="user", content=datum.message)],
         )
         predicted_answer = extract_last_message(response)
-        score = benchmark.metric(
-            predicted_answer, datum.answer, datum.message, agent_id
-        )
-        # print the score in red
-        # print("[red]Score: " + str(score) + "[/red]")
+        score = await benchmark.metric(predicted_answer, datum.answer, datum.message, agent_id)
         return (
             agent_id,
             score,
@@ -98,57 +86,39 @@ def run_single_data(datum, create_agent_fun, client, benchmark):
         )
     except Exception as e:
         print(f"[red]Error in run_single_data: {e}[/red]")
-        return (
-            agent_id,
-            0,
-            0,
-            0,
-        )
+        return (agent_id, 0, 0, 0)
 
 
-def evaluate_multithread(
+async def evaluate_concurrent(
     benchmark: Benchmark,
-    client: Letta,
-    create_agent_fun,
-    num_thread=8,
-    timeout=60,
+    client: AsyncLetta,
+    create_agent_fun: Callable[[AsyncLetta, Any], asyncio.Future],
+    timeout: int = 60,
 ):
     total = len(benchmark.dataset)
-    progress_bar = tqdm(total=total, desc="Score: 0/" + str(total))
+    progress_bar = tqdm(total=total, desc=f"Score: 0/{total}")
 
     agent_ids = []
     individual_scores = []
     input_tokens = 0
     output_tokens = 0
     total_score = 0
+    history: dict[str, tuple[str, list, list]] = {}
 
-    def process_datum_with_retry(datum, max_retries=5, timeout=None):
-        for attempt in range(max_retries):
-            try:
-                return process_datum(datum)
-            except Exception as e:
-                if attempt < max_retries - 1:
-                    continue
-                else:
-                    raise e
+    MAX_RETRIES = 5
 
-    def process_datum(datum):
-        agent_id = create_agent_fun(client, datum)
-        benchmark.setup_agent(
-            datum, client, agent_id
-        )  # sets up the agent for current data
-        response = benchmark.get_response(client, agent_id, datum)
-        # FIXME(shangyin) if get response does something this could fail
+    async def process_datum(datum: Any):
+        agent_id = await create_agent_fun(client, datum)
+        await benchmark.setup_agent(datum, client, agent_id)
+        response = await benchmark.get_response(client, agent_id, datum)
         input_message = datum.message
         response_messages = [m.model_dump(mode="json") for m in response.messages]
         all_messages = [
             m.model_dump(mode="json")
-            for m in client.agents.messages.list(agent_id=agent_id, limit=100)
+            for m in await client.agents.messages.list(agent_id=agent_id, limit=100)
         ]
         predicted_answer = extract_last_message(response)
-        score = benchmark.metric(predicted_answer, datum.answer, datum, agent_id)
-        # print the score in red
-        # print("[red]Score: " + str(score) + "[/red]")
+        score = await benchmark.metric(predicted_answer, datum.answer, datum, agent_id)
         return (
             agent_id,
             score,
@@ -159,49 +129,45 @@ def evaluate_multithread(
             all_messages,
         )
 
-    NUM_RETRIES = 5
-    with ThreadPoolExecutor(max_workers=num_thread) as executor:
-        future_to_datum = {
-            executor.submit(process_datum_with_retry, datum, NUM_RETRIES): datum
-            for datum in benchmark.dataset
-        }
-
-        total_success = 0
-
-        history = {}
-
-        agent_id = None
-
-        for future in as_completed(future_to_datum):
+    async def process_with_retry(datum: Any):
+        for attempt in range(MAX_RETRIES):
             try:
-                (
-                    agent_id,
-                    score,
-                    input_t,
-                    output_t,
-                    input_message,
-                    response_messages,
-                    all_messages,
-                ) = future.result(timeout=timeout * NUM_RETRIES)
-                agent_ids.append(agent_id)
-                individual_scores.append(score)
-                total_score += score
-                input_tokens += input_t
-                output_tokens += output_t
-                total_success += 1
-                history[agent_id] = (input_message, response_messages, all_messages)
-            except Exception as e:
-                current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                print(f"[red]Error in future: {e} at " + current_time)
-                print(traceback.format_exc())
-                print(f"[red] agent id is {agent_id}[/red]")
-                continue  # Skip failed future
+                return await process_datum(datum)
+            except Exception:
+                if attempt == MAX_RETRIES - 1:
+                    raise
 
-            progress_bar.set_description(f"Score: {total_score}/{total}")
-            progress_bar.update(1)
-            progress_bar.refresh()
+    tasks = [asyncio.create_task(process_with_retry(d)) for d in benchmark.dataset]
+
+    for task in asyncio.as_completed(tasks):
+        try:
+            (
+                agent_id,
+                score,
+                in_t,
+                out_t,
+                input_message,
+                response_messages,
+                all_messages,
+            ) = await asyncio.wait_for(task, timeout * MAX_RETRIES)
+            agent_ids.append(agent_id)
+            individual_scores.append(score)
+            total_score += score
+            input_tokens += in_t
+            output_tokens += out_t
+            history[agent_id] = (input_message, response_messages, all_messages)
+        except Exception as e:
+            now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            print(f"[red]Error in task: {e} at {now}[/red]")
+            print(traceback.format_exc())
+            continue
+
+        progress_bar.update(1)
+        progress_bar.set_description(f"Score: {total_score}/{total}")
+        progress_bar.refresh()
 
     progress_bar.close()
+
     return EvaluationResult(
         score=total_score,
         agent_ids=agent_ids,
@@ -212,117 +178,86 @@ def evaluate_multithread(
     )
 
 
-if __name__ == "__main__":
+async def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--benchmark",
         type=str,
-        help="the name of the benchmark - assuming benchmark_name/benchmark_name_benchmark.py exists",
+        help="Name of the benchmark module (e.g. foo/foo_benchmark.py)",
     )
-
     parser.add_argument(
         "--model",
         type=str,
-        help="""Model to use. Available: [azure-gpt-4o-mini,
-            bedrock-claude-3-5-sonnet,
-            claude-3-5-haiku,
-            claude-3-5-sonnet,
-            deepseek-reasoner,
-            gemini-pro,
-            gemini-vertex,
-            groq,
-            letta-hosted,
-            ollama,
-            openai-gpt-3.5-turbo,
-            openai-gpt-4o-mini,
-            openai-gpt-4o,
-            together-llama-3-1-405b,
-            together-llama-3-70b,
-            together-mistral-small-24B-Instruct-2501,
-            xai-grok-2,]""",
         default="openai-gpt-4o-mini",
+        help="Model to use",
     )
-
     parser.add_argument(
         "--num_threads",
         type=int,
-        help="Number of threads to use for evaluation",
         default=16,
+        help="Concurrency for evaluation",
     )
-
     parser.add_argument(
         "--output_file",
         type=str,
-        help="Output file to write the result",
         default="",
+        help="Base output file path",
     )
-
     parser.add_argument(
         "--dataset_size",
         type=int,
-        help="Size of the dataset to evaluate",
         default=100,
+        help="Number of datapoints to run",
     )
-
     parser.add_argument(
         "--timeout",
         type=int,
-        help="Timeout for each evaluation",
         default=60,
+        help="Per-task timeout in seconds",
     )
-
     parser.add_argument(
         "--benchmark_variable",
         type=str,
-        help="The variable name of the benchmark to use",
         default="benchmark",
+        help="Variable name in the module",
     )
-
     parser.add_argument(
         "--result_name_suffix",
         type=str,
         default="",
+        help="Suffix to append to result filenames",
     )
-
     parser.add_argument(
         "--repeat",
         type=int,
         default=1,
+        help="How many times to repeat",
     )
-
     parser.add_argument(
         "--repeat_from",
         type=int,
         default=0,
+        help="Start index for repeat",
     )
-
     parser.add_argument(
         "--letta_server",
         type=str,
         default="http://localhost:8283",
+        help="Base URL for Letta server",
     )
-
-    # import the benchmark
     args = parser.parse_args()
 
-    client_settings = {
-        "base_url": args.letta_server,
-    }
-    client = Letta(**client_settings)
+    client_settings = {"base_url": args.letta_server}
+    client = AsyncLetta(**client_settings)
 
-    bench = importlib.import_module(
+    bench_mod = importlib.import_module(
         f".{args.benchmark}.{args.benchmark}_benchmark", "leaderboard"
     )
+    benchmark: Benchmark = getattr(bench_mod, args.benchmark_variable)
 
-    benchmark: Benchmark = getattr(bench, args.benchmark_variable)
-
-    model = args.model
-
-    model_config_path = f"leaderboard/llm_model_configs/{model}.json"
-
+    model_config_path = f"leaderboard/llm_model_configs/{args.model}.json"
     with open(model_config_path) as f:
         model_config = json.load(f)
-
     llm_config = LlmConfig(**model_config)
     embedding_config = EmbeddingConfig(
         embedding_model="text-embedding-ada-002",
@@ -333,41 +268,37 @@ if __name__ == "__main__":
     )
 
     if getattr(benchmark, "create_agent_fun", None):
-        create_base_agent_fun = lambda client, datum: benchmark.create_agent_fun(
-            client, datum, llm_config, embedding_config
+        create_base_agent_fun = lambda c, d: benchmark.create_agent_fun(
+            c, d, llm_config, embedding_config
         )
-
     else:
-        create_base_agent_fun = lambda client, datum: create_base_agent(
-            client, datum, llm_config, embedding_config
-        )
+        create_base_agent_fun = create_base_agent
 
     benchmark.truncate_dataset(args.dataset_size)
 
     for i in range(args.repeat_from, args.repeat):
-        print(
-            f"[green]Running evaluation {i + 1}/{args.repeat} for {args.benchmark_variable} [/green]"
-        )
-        result = evaluate_multithread(
+        print(f"[green]Running eval {i+1}/{args.repeat} for {args.benchmark_variable}[/green]")
+        result = await evaluate_concurrent(
             benchmark,
             client,
             create_base_agent_fun,
-            num_thread=args.num_threads,
+            # num_thread=args.num_threads,
             timeout=args.timeout,
         )
-        os.makedirs(
-            f"results/{args.benchmark}_{args.benchmark_variable}_{args.dataset_size}",
-            exist_ok=True,
-        )
-        outfile_path = (
+        out_dir = f"results/{args.benchmark}_{args.benchmark_variable}_{args.dataset_size}"
+        os.makedirs(out_dir, exist_ok=True)
+        base = (
             args.output_file + f"_{i+1}"
             if args.output_file
-            else f"results/{args.benchmark}_{args.benchmark_variable}_{args.dataset_size}/{model}{args.result_name_suffix}_{i+1}"
+            else f"{out_dir}/{args.model}{args.result_name_suffix}_{i+1}"
         )
-        write_result(result, client_settings, model, f"{outfile_path}.json")
+        write_result(result, client_settings, args.model, f"{base}.json")
 
-        usage_statistics = benchmark.get_usage_statistics(
+        usage_stats = await benchmark.get_usage_statistics(
             client, result.agent_ids, evaluation_result=result
         )
+        write_usage_statistics(base, usage_stats)
 
-        write_usage_statistics(outfile_path, usage_statistics)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/leaderboard/letta_bench/letta_bench_benchmark.py
+++ b/leaderboard/letta_bench/letta_bench_benchmark.py
@@ -94,16 +94,20 @@ class LettaBenchmark(Benchmark):
         llm_config,
         embedding_config,
     ) -> str:
-        return (await client.agents.create(
-            llm_config=llm_config, embedding_config=embedding_config
-        )).id
+        return (
+            await client.agents.create(
+                llm_config=llm_config, embedding_config=embedding_config
+            )
+        ).id
 
     async def get_response(
         self, client: AsyncLetta, agent_id: str, datum: Dotdict
     ) -> LettaResponse:
         return await super().get_response(client, agent_id, datum)
 
-    async def metric(self, predicted: str, true: str, datum: Dotdict, agent_id: str) -> float:
+    async def metric(
+        self, predicted: str, true: str, datum: Dotdict, agent_id: str
+    ) -> float:
         result = await grade_sample(datum.message, true, predicted)
         return 1.0 if result == "A" else 0.0
 
@@ -193,7 +197,9 @@ class CoreMemoryReadBenchmark(LettaBenchmark):
         self, client: AsyncLetta, agent_id: str, datum: Dotdict
     ) -> LettaResponse:
         if self.hard:
-            return (await super().get_response_from_message_list(client, agent_id, datum))[-1]
+            return (
+                await super().get_response_from_message_list(client, agent_id, datum)
+            )[-1]
         return await super().get_response(client, agent_id, datum)
 
 
@@ -293,9 +299,9 @@ class CoreMemoryUpdateBenchmark(LettaBenchmark):
             agent_id=agent_id,
             messages=[MessageCreate(role="user", content=datum.contradicting_fact)],
         )
-        self.agent_core_memory_update_messages[agent_id] = await client.agents.messages.list(
-            agent_id=agent_id, limit=1000
-        )
+        self.agent_core_memory_update_messages[
+            agent_id
+        ] = await client.agents.messages.list(agent_id=agent_id, limit=1000)
         await client.agents.messages.reset(agent_id=agent_id)
 
     async def get_usage_statistics(

--- a/leaderboard/utils.py
+++ b/leaderboard/utils.py
@@ -25,14 +25,15 @@ class EvaluationResult:
     usage: dict = None
 
 
-
 @dataclass
 class UsageStatistics:
     run_stat: dict
     agent_stat: dict
 
 
-async def total_archival_usage(client: AsyncLetta, agent_ids: list[str], individual_scores: list[float]):
+async def total_archival_usage(
+    client: AsyncLetta, agent_ids: list[str], individual_scores: list[float]
+):
     total_archival_memory = 0
     total_archival_score = 0
     agent_archival_ids = []
@@ -54,15 +55,24 @@ async def total_archival_usage(client: AsyncLetta, agent_ids: list[str], individ
     }
 
 
-async def add_archival_usage_to_json(client: AsyncLetta, agent_ids: list[str], individual_scores: list[float], file_path: str):
+async def add_archival_usage_to_json(
+    client: AsyncLetta,
+    agent_ids: list[str],
+    individual_scores: list[float],
+    file_path: str,
+):
     with open(file_path) as f:
         data = json.load(f)
-    data["archival_usage"] = await total_archival_usage(client, agent_ids, individual_scores)
+    data["archival_usage"] = await total_archival_usage(
+        client, agent_ids, individual_scores
+    )
     with open(file_path, "w") as f:
         json.dump(data, f)
 
 
-def write_result_to_json(result: EvaluationResult, client_settings: dict, model: str, output_file: str):
+def write_result_to_json(
+    result: EvaluationResult, client_settings: dict, model: str, output_file: str
+):
     with open(output_file, "w") as f:
         json.dump(
             {
@@ -79,13 +89,19 @@ def write_result_to_json(result: EvaluationResult, client_settings: dict, model:
     print(f"[green]Result written to {output_file}[/green]")
 
 
-def write_result(result: EvaluationResult, client_settings: dict, model: str, output_file: str):
+def write_result(
+    result: EvaluationResult, client_settings: dict, model: str, output_file: str
+):
     write_result_to_json(result, client_settings, model, output_file)
     output_path = os.path.dirname(output_file)
     subdir = os.path.splitext(os.path.basename(output_file))[0]
     agent_dir = os.path.join(output_path, subdir)
     os.makedirs(agent_dir, exist_ok=True)
-    for agent_id, (input_message, output_messages, all_messages) in result.history.items():
+    for agent_id, (
+        input_message,
+        output_messages,
+        all_messages,
+    ) in result.history.items():
         agent_file_path = os.path.join(agent_dir, f"{agent_id}.json")
         with open(agent_file_path, "w") as f:
             json.dump(
@@ -118,7 +134,9 @@ class Dotdict(dict):
         try:
             return super().__getitem__(key)
         except KeyError as e:
-            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{key}'") from e
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{key}'"
+            ) from e
 
     def __setattr__(self, key, value):
         super().__setitem__(key, value)
@@ -127,7 +145,9 @@ class Dotdict(dict):
         try:
             super().__delitem__(key)
         except KeyError as e:
-            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{key}'") from e
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{key}'"
+            ) from e
 
 
 GRADER_TEMPLATE = """
@@ -215,7 +235,6 @@ Just return the letters "A", "B", or "C", with no text around it.
 CHOICE_LETTERS = ["A", "B", "C"]
 CHOICE_STRINGS = ["CORRECT", "INCORRECT", "NOT_ATTEMPTED"]
 CHOICE_LETTER_TO_STRING = dict(zip(CHOICE_LETTERS, CHOICE_STRINGS))
-
 
 
 async def grade_sample(question: str, target: str, predicted_answer: str) -> str:
@@ -383,6 +402,8 @@ if __name__ == "__main__":
                 total_input_tokens,
                 total_output_tokens,
             ) = collect_stat(result_dir, model, True)
-            print(f"{model},{round(mean_score, 2)},{total_input_tokens},{total_output_tokens}")
+            print(
+                f"{model},{round(mean_score, 2)},{total_input_tokens},{total_output_tokens}"
+            )
 
     asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ letta
 rich
 letta_client
 datasets
-tqdm
+ruff

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ letta
 rich
 letta_client
 datasets
+tqdm

--- a/run_all_benchmark.sh
+++ b/run_all_benchmark.sh
@@ -30,7 +30,7 @@ for model in "$@"; do
             --dataset_size="$dataset_size" \
             --timeout=300 \
             --repeat=3 \
-            --num_threads=16 \
+            --max_concurrency=16 \
             --model="$model"
 
         result_dir="results/letta_bench_${benchmark}_${dataset_size}"


### PR DESCRIPTION
- Add --max_concurrency flag and limit async task concurrency using asyncio.Semaphore.
- Made evaluation fully async using AsyncLetta and OpenAI’s async client
- Parallelized benchmark runs with asyncio for better performance

Also investigated scaling up the Letta server, some recommended settings for my machine (M3 Max Macbook):

```
export LETTA_PG_POOL_SIZE=25
export LETTA_PG_MAX_OVERFLOW=10
export LETTA_UVICORN_WORKERS=10
```
